### PR TITLE
Fix step when multiple relations exist between the two joined objects

### DIFF
--- a/src/SilverStripe/BehatExtension/Context/FixtureContext.php
+++ b/src/SilverStripe/BehatExtension/Context/FixtureContext.php
@@ -249,13 +249,13 @@ class FixtureContext extends BehatContext
 	}
 
  	/**
-	 * Assign a type of object to another type of object
-	 * The base object will be created if it does not exist already
-	 * Assumption: one object has relationship  (has_one, has_many or many_many ) with the other object
-	 * @example I assign the "TaxonomyTerm" "For customers" to the "Page" "Page1"
-	 * @Given /^I assign (?:(an|a|the) )"(?<type>[^"]+)" "(?<value>[^"]+)" to (?:(an|a|the) )"(?<relationType>[^"]+)" "(?<relationId>[^"]+)"$/
+	 * Assign a type of object to another type of object. The base object will be created if it does not exist already.
+	 * If the last part of the string (in the "X" relation) is omitted, then the first matching relation will be used.
+	 * 
+	 * @example I assign the "TaxonomyTerm" "For customers" to the "Page" "Page1" in the "Terms" relation
+	 * @Given /^I assign (?:(an|a|the) )"(?<type>[^"]+)" "(?<value>[^"]+)" to (?:(an|a|the) )"(?<relationType>[^"]+)" "(?<relationId>[^"]+)"(?:( in the "(?<relationName>[^"]+)" relation)*)$/
 	 */
-	public function stepIAssignObjToObj($type, $value, $relationType, $relationId) {
+	public function stepIAssignObjToObj($type, $value, $relationType, $relationId, $relationName = "") {
 		$class = $this->convertTypeToClass($type);
 		$relationClass = $this->convertTypeToClass($relationType);
 
@@ -266,15 +266,22 @@ class FixtureContext extends BehatContext
 		// Check if there is relationship defined in many_many (includes belongs_many_many)
 		$manyField = null;
 		$oneField = null;
+
 		if ($relationObj->many_many()) {
 			$manyField = array_search($class, $relationObj->many_many());
+			if($manyField && strlen($relationName) > 0) $manyField = $relationName;
 		}
+
 		if(empty($manyField) && $relationObj->has_many()) {
 			$manyField = array_search($class, $relationObj->has_many());
+			if($manyField && strlen($relationName) > 0) $manyField = $relationName;
 		}
+
 		if(empty($manyField) && $relationObj->has_one()) {
 			$oneField = array_search($class, $relationObj->has_one());
+			if($oneField && strlen($relationName) > 0) $oneField = $relationName;
 		}
+
 		if(empty($manyField) && empty($oneField)) {
 			throw new \Exception("'$relationClass' has no relationship (has_one, has_many and many_many) with '$class'!");
 		}

--- a/src/SilverStripe/BehatExtension/Context/FixtureContext.php
+++ b/src/SilverStripe/BehatExtension/Context/FixtureContext.php
@@ -248,14 +248,25 @@ class FixtureContext extends BehatContext
 		}
 	}
 
+	/**
+	 * Assign a type of object to another type of object. The base object will be created if it does not exist already.
+	 * If the last part of the string (in the "X" relation) is omitted, then the first matching relation will be used.
+	 *
+	 * @example I assign the "TaxonomyTerm" "For customers" to the "Page" "Page1"
+	 * @Given /^I assign (?:(an|a|the) )"(?<type>[^"]+)" "(?<value>[^"]+)" to (?:(an|a|the) )"(?<relationType>[^"]+)" "(?<relationId>[^"]+)"$/
+	 */
+	public function stepIAssignObjToObj($type, $value, $relationType, $relationId) {
+		self::stepIAssignObjToObjInTheRelation($type, $value, $relationType, $relationId, null);
+	}
+
  	/**
 	 * Assign a type of object to another type of object. The base object will be created if it does not exist already.
 	 * If the last part of the string (in the "X" relation) is omitted, then the first matching relation will be used.
 	 * 
 	 * @example I assign the "TaxonomyTerm" "For customers" to the "Page" "Page1" in the "Terms" relation
-	 * @Given /^I assign (?:(an|a|the) )"(?<type>[^"]+)" "(?<value>[^"]+)" to (?:(an|a|the) )"(?<relationType>[^"]+)" "(?<relationId>[^"]+)"(?:( in the "(?<relationName>[^"]+)" relation)*)$/
+	 * @Given /^I assign (?:(an|a|the) )"(?<type>[^"]+)" "(?<value>[^"]+)" to (?:(an|a|the) )"(?<relationType>[^"]+)" "(?<relationId>[^"]+)" in the "(?<relationName>[^"]+)" relation$/
 	 */
-	public function stepIAssignObjToObj($type, $value, $relationType, $relationId, $relationName = "") {
+	public function stepIAssignObjToObjInTheRelation($type, $value, $relationType, $relationId, $relationName) {
 		$class = $this->convertTypeToClass($type);
 		$relationClass = $this->convertTypeToClass($relationType);
 


### PR DESCRIPTION
If you have two objects that have multiple relation tuples, this allows you to specify which relation to save into. For example:

``` php
class Page extends SiteTree {
    private static $many_many = array(
        "Categories" => "TaxonomyTerm",
        "Audiences" => "TaxonomyTerm"
    );
}
```

You can now run Behat steps like:

``` gherkin
Given I assign the "Taxonomy Term" "Category 1" to the "Page" "Page 1" # This is the default, and will save into the 'Categories' relation first
Given I assign the "Taxonomy Term" "Category 2" to the "Page" "Page 1" in the "Categories" relation # This is equivalent to the first line, but makes it explicit
Given I assign the "Taxonomy Term" "Audience 1" to the "Page" "Page 1" in the "Audiences" relation # This was not possible before
```
